### PR TITLE
Remove the use of jQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,10 @@ Easy pages can be included in xpage templates using the following ajax call.
 ```html
 <div id="pages_home"></div>
 <script type="text/javascript">
-  fetch('/page/home?mainonly=yes').then(res => {
-    document.getElementById('pages_home').innerHTML = res;
+  fetch('/page/home?mainonly=yes').then((res) => {
+    res.text().then((text) => {
+      document.getElementById('pages_home').innerHTML = text;
+    });
   });
 </script>
 ```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ Easy pages can be included in xpage templates using the following ajax call.
 ```html
 <div id="pages_home"></div>
 <script type="text/javascript">
-  jQuery("#pages_home").load( "/page/home?mainonly=yes" );
+  fetch('/page/home?mainonly=yes').then(res => {
+    document.getElementById('pages_home').innerHTML = res;
+  });
 </script>
 ```
 

--- a/lang/en/static/index_pages_example.xpage
+++ b/lang/en/static/index_pages_example.xpage
@@ -9,12 +9,16 @@
 <div style="margin: 0 auto; width: 700px;">
   <div id="pages_home"></div>
   <script type="text/javascript">
-    jQuery("#pages_home").load( "/page/home?mainonly=yes" );
+    fetch('/page/home?mainonly=yes').then(res => {
+      document.getElementById('pages_home').innerHTML = res;
+    });
   </script>
 
   <div id="pages_index"></div>
   <script type="text/javascript">
-    jQuery("#pages_index").load( "/cgi/pages.embed" );
+    fetch('/cgi/pages.embed').then(res => {
+      document.getElementById('pages_index').innerHTML = res;
+    });
   </script>
 </div>
 

--- a/lang/en/static/index_pages_example.xpage
+++ b/lang/en/static/index_pages_example.xpage
@@ -9,15 +9,19 @@
 <div style="margin: 0 auto; width: 700px;">
   <div id="pages_home"></div>
   <script type="text/javascript">
-    fetch('/page/home?mainonly=yes').then(res => {
-      document.getElementById('pages_home').innerHTML = res;
+    fetch('/page/home?mainonly=yes').then((res) => {
+      res.text().then((text) => {
+        document.getElementById('pages_home').innerHTML = text;
+      });
     });
   </script>
 
   <div id="pages_index"></div>
   <script type="text/javascript">
-    fetch('/cgi/pages.embed').then(res => {
-      document.getElementById('pages_index').innerHTML = res;
+    fetch('/cgi/pages.embed').then((res) => {
+      res.text().then((text) => {
+        document.getElementById('pages_index').innerHTML = text;
+      });
     });
   </script>
 </div>


### PR DESCRIPTION
As we no longer bundle jQuery it doesn't make sense to use it here, particularly with `easy_pages` being included by default in 3.5 (removing jQuery in https://github.com/eprints/eprints3.5/pull/183). It was only used in the README and an example and could easily be replaced with the fetch API.