### PR TITLE
Automatically set the width and prevent it from being altered

### DIFF
--- a/lang/en/static/javascript/auto/65_easy_pages.js
+++ b/lang/en/static/javascript/auto/65_easy_pages.js
@@ -21,9 +21,8 @@ var initTinyMCE_for_easy_pages = function(id,replacements, preview_substitutions
 
             // General:
             selector: id,
-            resize: 'both',
+            resize: 'height',
             height: 500,
-            width: 700,
             //cache_suffix: '?'+ new Date().getTime(), // Doesn't appear to work with 4.6.1 so commented out in favour of manually adding to the end of content_css further below.
             relative_urls : true,
             //document_base_url : 'http://example.eprints.org/', - as a value unique to each repository, this should be passed in or commented out/left at default.


### PR DESCRIPTION
If we don't set the width it will automatically fill the box its in which seems to make logical sense and it feels nicer to then not be able to change the width as otherwise you accidentally shift it one way or the other while trying to adjust the height.

I originally noticed this because some of the buttons (link, image, code and preview) were being hidden in a dropdown menu by default which didn't make much sense.

Old:
<img width="2630" height="304" alt="image" src="https://github.com/user-attachments/assets/e58c1716-483d-4348-b599-80abdda38a43" />
New:
<img width="1314" height="154" alt="image" src="https://github.com/user-attachments/assets/957f5c16-baf5-4187-85e3-7f98b60a2475" />